### PR TITLE
adopted to rtabmap_ros

### DIFF
--- a/launch/teleop.launch
+++ b/launch/teleop.launch
@@ -33,6 +33,6 @@
 		<param name="base_frame" value="base_frame"/>
 	</node>
 
-	<node pkg="tf" type="static_transform_publisher" name="base_frame_to_laser" args="0.0 0.0 0.0 0.0 0.0 0.0 /base_frame /laser 50" />
+	<node pkg="tf" type="static_transform_publisher" name="base_frame_to_laser" args="0.0 0.0 0.0 -1.5708 0.0 -1.5708 /base_frame /laser 50" />
 
 </launch>

--- a/src/envs/physics_env.py
+++ b/src/envs/physics_env.py
@@ -192,11 +192,5 @@ class PhysicsEnv(Env):
         vel_control.controlling_ang_vel = True
         vel_control.lin_vel_is_local = True
         vel_control.ang_vel_is_local = True
-        if(linear_vel):
-            vel_control.linear_velocity = linear_vel
-        else:
-            vel_control.linear_velocity = np.array([0.0,0.0,0.0])
-        if(angular_vel):
-            vel_control.angular_velocity = angular_vel
-        else:
-            vel_control.angular_velocity = np.array([0.0,0.0,0.0])
+        vel_control.linear_velocity = linear_vel
+        vel_control.angular_velocity = angular_vel

--- a/src/envs/physics_env.py
+++ b/src/envs/physics_env.py
@@ -192,5 +192,11 @@ class PhysicsEnv(Env):
         vel_control.controlling_ang_vel = True
         vel_control.lin_vel_is_local = True
         vel_control.ang_vel_is_local = True
-        vel_control.linear_velocity = linear_vel
-        vel_control.angular_velocity = angular_vel
+        if(linear_vel):
+            vel_control.linear_velocity = linear_vel
+        else:
+            vel_control.linear_velocity = np.array([0.0,0.0,0.0])
+        if(angular_vel):
+            vel_control.angular_velocity = angular_vel
+        else:
+            vel_control.angular_velocity = np.array([0.0,0.0,0.0])

--- a/src/nodes/habitat_env_node.py
+++ b/src/nodes/habitat_env_node.py
@@ -448,6 +448,7 @@ class HabitatEnvNode:
             if sensor_uuid in ["rgb", "depth", "pointgoal_with_gps_compass"]:
                 h = Header()
                 h.stamp = t_curr
+                h.frame_id = 'laser'
                 sensor_msg.header = h
                 observations_ros[sensor_uuid] = sensor_msg
 


### PR DESCRIPTION
I made it to use rtabmap_ros with this package, and these are the small changes I made to this package.
1. rtabmap_ros requires the frame_id of sensor data.
2. the tf between base_link and camera_link is incorrect because the coordinate of images is different from the coordinate of links.